### PR TITLE
docs: fix example function errors in documentation

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -156,7 +156,7 @@ Here is an image showing One Tap prompt
 While using One-tap feature, a [dead-loop UX issue](https://developers.google.com/identity/gsi/web/guides/automatic-sign-in-sign-out#sign-out) may occur. To resolve this issue, in your logout function run `googleLogout` funtion
 ```javascript
 import { googleLogout } from "vue3-google-login"
-const yourLogoutFunction() {
+const yourLogoutFunction = () => {
   // your logout logics
   googleLogout()
 }


### PR DESCRIPTION
 fix example function  [errors ](https://devbaji.github.io/vue3-google-login/#use-of-googlelogout-function) in documentation
![image](https://github.com/user-attachments/assets/ce5434b0-24f1-4bf7-9d61-dd440435d279)
