### PR TITLE
Support nonce property in ButtonConfig

### DIFF
--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -29,6 +29,8 @@ export interface ButtonConfig {
   width?: string;
   /** If set, then the button [language](https://developers.google.com/identity/gsi/web/reference/js-reference#locale) is rendered */
   locale?: string;
+  /** The button [nonce](https://developers.google.com/identity/gsi/web/reference/js-reference#nonce) */
+  nonce?: string;
 }
 
 /**

--- a/src/plugin/utils.ts
+++ b/src/plugin/utils.ts
@@ -54,6 +54,7 @@ export const loadGApi = () => new Promise<types.Google>((resolve, reject) => {
     script.src = config.library;
     script.async = true;
     script.defer = true;
+    script.nonce = state.buttonConfig.nonce;
     document.head.appendChild(script);
   }
 });


### PR DESCRIPTION
For security reasons (CSP headers) we must support nonce.